### PR TITLE
Use fmt.Print for regular output, remove logrus timestamps

### DIFF
--- a/cmd/binding.go
+++ b/cmd/binding.go
@@ -121,19 +121,19 @@ func addBinding(args []string) {
 		return
 	}
 
-	log.Printf("Successfully created secret [%v] in namespace [%v].\n", newSecretName, bindingNamespace)
-	log.Printf("Type the following command to attach the binding to your application:\n")
-	log.Printf("oc set env dc/%v --from=secret/%v\n", appName, newSecretName)
+	fmt.Printf("Successfully created secret [%v] in namespace [%v].\n", newSecretName, bindingNamespace)
+	fmt.Printf("Type the following command to attach the binding to your application:\n")
+	fmt.Printf("oc set env dc/%v --from=secret/%v\n", appName, newSecretName)
 	return
 
 }
 
 func listBindings() {
-	log.Println("listBindings called")
+	fmt.Println("listBindings called")
 }
 
 func removeBinding() {
-	log.Println("removeBinding called")
+	fmt.Println("removeBinding called")
 }
 
 // ExtractCredentialsAsSecret - Extract credentials from APB as secret in namespace.

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -17,6 +17,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/automationbroker/bundle-lib/bundle"
 	"github.com/automationbroker/bundle-lib/registries"
 	"github.com/spf13/cobra"
@@ -97,9 +99,9 @@ func listImages() {
 		return
 	}
 	if len(specs) > 0 && Refresh == false {
-		log.Println("Found specs already in config")
+		fmt.Println("Found specs already in config")
 		for _, s := range specs {
-			log.Printf("%v - %v\n", s.FQName, s.Image)
+			fmt.Printf("%v - %v\n", s.FQName, s.Image)
 		}
 		return
 	}
@@ -109,7 +111,7 @@ func listImages() {
 		log.Error("Error getting images")
 		return
 	}
-	log.Printf("specs: %v\n", specs)
+	fmt.Printf("specs: %v\n", specs)
 	err = updateCachedList(specs)
 	if err != nil {
 		log.Error("Error updating cache")
@@ -117,6 +119,6 @@ func listImages() {
 	}
 
 	for _, s := range specs {
-		log.Printf("%v - %v\n", s.FQName, s.Image)
+		fmt.Printf("%v - %v\n", s.FQName, s.Image)
 	}
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -90,7 +90,7 @@ func runBundle(action string, args []string) {
 	if plan.Name == "" {
 		log.Warning("Did not find a selected plan")
 	} else {
-		log.Printf("Plan: %v\n", plan.Name)
+		fmt.Printf("Plan: %v\n", plan.Name)
 	}
 	params := selectParameters(plan)
 	extraVars, err := createExtraVars(execNamespace, &params, plan)
@@ -149,16 +149,16 @@ func runBundle(action string, args []string) {
 		log.Errorf("Failed to create pod: %v", err)
 		return
 	}
-	log.Printf("Successfully created pod [%v] to %s [%v] in namespace [%v]\n", pn, ec.Action, execName, execNamespace)
+	fmt.Printf("Successfully created pod [%v] to %s [%v] in namespace [%v]\n", pn, ec.Action, execName, execNamespace)
 	return
 }
 
 func selectPlan(spec *bundle.Spec) bundle.Plan {
 	var planName string
 	if len(spec.Plans) > 1 {
-		log.Printf("List of available plans:\n")
+		fmt.Printf("List of available plans:\n")
 		for _, plan := range spec.Plans {
-			log.Printf("name: %v\n", plan.Name)
+			fmt.Printf("name: %v\n", plan.Name)
 		}
 		fmt.Printf("Enter name of plan you'd like to deploy: ")
 		fmt.Scanln(&planName)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,7 +56,7 @@ postgres database to my kubernetes cluster.`,
 }
 
 func init() {
-	log.SetLevel(log.WarnLevel)
+	log.SetLevel(log.InfoLevel)
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().StringVar(&CfgFile, "config", "", "configuration file (default is $HOME/.sbcli)")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -57,6 +57,8 @@ postgres database to my kubernetes cluster.`,
 
 func init() {
 	log.SetLevel(log.InfoLevel)
+	log.SetFormatter(&log.TextFormatter{DisableTimestamp: true})
+
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().StringVar(&CfgFile, "config", "", "configuration file (default is $HOME/.sbcli)")


### PR DESCRIPTION
 - Set default logging level to "info" instead of "warning"
 - Switch to fmt.Print[f,ln] instead of log.Print[f,ln] for regular command output
 - Remove timestamps in `[0000]` format from logrus output