### PR TITLE
Uniformly size columns + add labels to spec list output.

### DIFF
--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	"github.com/automationbroker/bundle-lib/registries"
+	"github.com/automationbroker/sbcli/util"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -105,6 +106,23 @@ func addRegistry() {
 	return
 }
 
+func printRegistries(regList []registries.Config) {
+	colName := util.TableColumn{Header: "NAME"}
+	colType := util.TableColumn{Header: "TYPE"}
+	colOrg := util.TableColumn{Header: "ORG"}
+	colURL := util.TableColumn{Header: "URL"}
+
+	for _, r := range regList {
+		colName.Data = append(colName.Data, r.Name)
+		colType.Data = append(colType.Data, r.Type)
+		colOrg.Data = append(colOrg.Data, r.Org)
+		colURL.Data = append(colURL.Data, r.URL)
+	}
+
+	tableToPrint := []util.TableColumn{colName, colType, colOrg, colURL}
+	util.PrintTable(tableToPrint)
+}
+
 func listRegistries() {
 	var regList []registries.Config
 	err := viper.UnmarshalKey("Registries", &regList)
@@ -114,9 +132,7 @@ func listRegistries() {
 	}
 	if len(regList) > 0 {
 		fmt.Println("Found registries already in config:")
-		for _, r := range regList {
-			fmt.Printf("name: %v - type: %v - organization: %v - URL: %v\n", r.Name, r.Type, r.Org, r.URL)
-		}
+		printRegistries(regList)
 	} else {
 		fmt.Println("Found no registries in configuration. Try `sbcli registry add`.")
 	}

--- a/util/table_printer.go
+++ b/util/table_printer.go
@@ -1,0 +1,82 @@
+//
+// Copyright (c) 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package util
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// TableColumn objects can be printed with func PrintTable()
+type TableColumn struct {
+	Header string
+	Data   []string
+}
+
+// PrintTable prints a list of TableColumns to the CLI with auto-sized columns and dividers
+func PrintTable(tableColumns []TableColumn) {
+	// Define table formatting
+	baseFormatString := " %%-%ss  "
+	dividerString := " | "
+
+	// Vars for keeping track of column widths
+	columnWidth := make(map[string]int)
+	columnWidthStr := make(map[string]string)
+
+	// Set appropriate column width for all columns
+	for _, column := range tableColumns {
+		for _, cellData := range column.Data {
+			if len(cellData) > columnWidth[column.Header] {
+				columnWidth[column.Header] = len(cellData)
+				columnWidthStr[column.Header] = strconv.Itoa(len(cellData))
+			}
+		}
+	}
+
+	// Print column header
+	for i, column := range tableColumns {
+		formatString := fmt.Sprintf(baseFormatString, columnWidthStr[column.Header])
+		if i < (len(tableColumns)) && i > 0 {
+			fmt.Print(dividerString)
+		}
+		fmt.Printf(formatString, column.Header)
+	}
+	fmt.Println()
+
+	// Print header to content divider (---)
+	for i, column := range tableColumns {
+		formatString := fmt.Sprintf(baseFormatString, columnWidthStr[column.Header])
+		if i < (len(tableColumns)) && i > 0 {
+			fmt.Print(dividerString)
+		}
+		fmt.Printf(formatString, strings.Repeat("-", columnWidth[column.Header]))
+	}
+	fmt.Println()
+
+	// Print table contents
+	for rowIndex := range tableColumns[0].Data {
+		for i, column := range tableColumns {
+			formatString := fmt.Sprintf(baseFormatString, columnWidthStr[column.Header])
+			if i < (len(tableColumns)) && i > 0 {
+				fmt.Print(dividerString)
+			}
+			fmt.Printf(formatString, column.Data[rowIndex])
+		}
+		fmt.Println()
+	}
+}


### PR DESCRIPTION
Output of `sbcli bundle list` now looks like this:

```
BUNDLE                 |  IMAGE
---------------------  |  -------------------------------------------------------------------
es-apb                 |  docker.io/ansibleplaybookbundle/es-apb:latest
hello-world-apb        |  docker.io/ansibleplaybookbundle/hello-world-apb:latest
vnc-desktop-apb        |  docker.io/ansibleplaybookbundle/vnc-desktop-apb:latest
kibana-apb             |  docker.io/ansibleplaybookbundle/kibana-apb:latest
pyzip-demo-apb         |  docker.io/ansibleplaybookbundle/pyzip-demo-apb:latest
mssql-remote-apb       |  docker.io/ansibleplaybookbundle/mssql-remote-apb:latest
mongodb-apb            |  docker.io/ansibleplaybookbundle/mongodb-apb:latest
import-vm-disk-apb     |  docker.io/ansibleplaybookbundle/import-vm-disk-apb:latest
```