### PR TITLE
Add kubectl-esque completion for bash and zsh.

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,75 @@
+//
+// Copyright (c) 2018 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var completionCmd = &cobra.Command{
+	Use:   "completion",
+	Short: "Generates shell completion scripts.",
+	Long: `To load sbcli completion run
+
+source <(sbcli completion bash)
+-- or --
+source <(sbcli completion zsh)
+
+`,
+}
+
+var bashCompletionCmd = &cobra.Command{
+	Use:   "bash",
+	Short: "Generates bash completion scripts",
+	Long: `To load bash completion run
+
+source <(sbcli completion bash)
+
+To configure your bash shell to load completions for each session add to your bashrc
+
+# ~/.bashrc or ~/.profile
+source <(sbcli completion bash)
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		rootCmd.GenBashCompletion(os.Stdout)
+	},
+}
+
+var zshCompletionCmd = &cobra.Command{
+	Use:   "zsh",
+	Short: "Generates zsh completion scripts",
+	Long: `To load zsh completion run
+
+. <(sbcli completion zsh)
+
+To configure your zsh shell to load completions for each session add to your zshrc
+
+# ~/.zshrc or ~/.zprofile
+source <(kubectl completion zsh)
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		rootCmd.GenZshCompletion(os.Stdout)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(completionCmd)
+	completionCmd.AddCommand(bashCompletionCmd)
+	completionCmd.AddCommand(zshCompletionCmd)
+}


### PR DESCRIPTION
 - Add `bash` completion
 - Add `zsh` completion

To use either of these completion features, run the appropriate command for your shell:

```
# bash
source <(sbcli completion bash)

# zsh
source <(sbcli completion zsh)
```