### PR TITLE
Specs under registries

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -144,7 +144,7 @@ func listImages() {
 		fmt.Printf("Getting specs for registry: [%s]\n", regConfig.Config.Name)
 		specs, err := getImages(regConfig)
 		if err != nil {
-			log.Error("Error getting images")
+			log.Errorf("Error getting images - %v", err)
 			continue
 		}
 
@@ -155,7 +155,7 @@ func listImages() {
 
 	err = updateCachedRegistries(newRegConfigs)
 	if err != nil {
-		log.Error("Error updating cache")
+		log.Errorf("Error updating cache - %v", err)
 		return
 	}
 }

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -122,7 +122,7 @@ func printRegConfigSpecs(regConfigs []Registry) {
 	}
 
 	tableToPrint := []*util.TableColumn{colFQName, colImage, colRegName}
-	util.PrintTable(tableToPrint, nil)
+	util.PrintTable(tableToPrint)
 }
 
 func listImages() {

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -84,43 +84,27 @@ func init() {
 	bundleCmd.AddCommand(bundleDeprovisionCmd)
 }
 
-func updateCachedList(specs []*bundle.Spec) error {
-	viper.Set("Specs", specs)
-	viper.WriteConfig()
-	return nil
-}
-
-func getImages() ([]*bundle.Spec, error) {
-	var regConfigList []registries.Config
-	var regList []registries.Registry
+// Get images from a single registry
+func getImages(registryMetadata Registry) ([]*bundle.Spec, error) {
 	var specList []*bundle.Spec
-	err := viper.UnmarshalKey("Registries", &regConfigList)
+
+	authNamespace := ""
+	registry, err := registries.NewRegistry(registryMetadata.Config, authNamespace)
 	if err != nil {
-		log.Error("Error unmarshalling config: ", err)
+		log.Error("Error from creating a NewRegistry")
+		log.Error(err)
 		return nil, err
 	}
 
-	authNamespace := ""
-	for _, config := range regConfigList {
-		registry, err := registries.NewRegistry(config, authNamespace)
-		if err != nil {
-			log.Error("Error from creating a NewRegistry")
-			log.Error(err)
-			return nil, err
-		}
-		regList = append(regList, registry)
+	specs, count, err := registry.LoadSpecs()
+	if err != nil {
+		log.Errorf("registry: %v was unable to complete bootstrap - %v",
+			registry.RegistryName(), err)
+		return nil, err
 	}
-	for _, reg := range regList {
-		specs, count, err := reg.LoadSpecs()
-		if err != nil {
-			log.Errorf("registry: %v was unable to complete bootstrap - %v",
-				reg.RegistryName(), err)
-			return nil, err
-		}
-		log.Infof("Registry %v has %d bundles available from %d images scanned", reg.RegistryName(), len(specs), count)
-		specList = append(specList, specs...)
-	}
+	log.Infof("Registry %v has %d bundles available from %d images scanned", registry.RegistryName(), len(specs), count)
 
+	specList = append(specList, specs...)
 	return specList, nil
 }
 
@@ -138,26 +122,41 @@ func printSpecs(specs []*bundle.Spec) {
 }
 
 func listImages() {
-	var specs []*bundle.Spec
-	err := viper.UnmarshalKey("Specs", &specs)
+	var regConfigs []Registry
+	var newRegConfigs []Registry
+
+	err := viper.UnmarshalKey("Registries", &regConfigs)
 	if err != nil {
 		log.Error("Error unmarshalling config: ", err)
 		return
 	}
-	if len(specs) > 0 && Refresh == false {
-		fmt.Println("Found specs already in config")
-		printSpecs(specs)
-		return
+
+	for _, regConfig := range regConfigs {
+		if len(regConfig.Specs) > 0 && Refresh == false {
+			fmt.Println("Found specs already in config")
+			for _, s := range regConfig.Specs {
+				fmt.Printf("%v - %v\n", s.FQName, s.Image)
+			}
+			newRegConfigs = append(newRegConfigs, regConfig)
+			continue
+		}
+		specs, err := getImages(regConfig)
+		if err != nil {
+			log.Error("Error getting images")
+			return
+		}
+
+		regConfig.Specs = specs
+		newRegConfigs = append(newRegConfigs, regConfig)
+
+		for _, s := range specs {
+			fmt.Printf("%v - %v\n", s.FQName, s.Image)
+		}
 	}
-	specs, err = getImages()
-	if err != nil {
-		log.Error("Error getting images")
-		return
-	}
-	err = updateCachedList(specs)
+
+	err = updateCachedRegistries(newRegConfigs)
 	if err != nil {
 		log.Error("Error updating cache")
 		return
 	}
-	printSpecs(specs)
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -61,7 +61,7 @@ var zshCompletionCmd = &cobra.Command{
 To configure your zsh shell to load completions for each session add to your zshrc
 
 # ~/.zshrc or ~/.zprofile
-source <(kubectl completion zsh)
+source <(sbcli completion zsh)
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		rootCmd.GenZshCompletion(os.Stdout)

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -126,7 +126,7 @@ func printRegistries(regList []Registry) {
 	}
 
 	tableToPrint := []*util.TableColumn{colName, colType, colOrg, colURL}
-	util.PrintTable(tableToPrint, nil)
+	util.PrintTable(tableToPrint)
 }
 
 func listRegistries() {

--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -32,7 +32,6 @@ type Registry struct {
 	Specs  []*bundle.Spec
 }
 
-// var registryConfig registries.Config
 var registryConfig Registry
 var whitelist string
 var removeName string
@@ -113,21 +112,21 @@ func addRegistry() {
 	return
 }
 
-func printRegistries(regList []registries.Config) {
-	colName := util.TableColumn{Header: "NAME"}
-	colType := util.TableColumn{Header: "TYPE"}
-	colOrg := util.TableColumn{Header: "ORG"}
-	colURL := util.TableColumn{Header: "URL"}
+func printRegistries(regList []Registry) {
+	colName := &util.TableColumn{Header: "NAME"}
+	colType := &util.TableColumn{Header: "TYPE"}
+	colOrg := &util.TableColumn{Header: "ORG"}
+	colURL := &util.TableColumn{Header: "URL"}
 
 	for _, r := range regList {
-		colName.Data = append(colName.Data, r.Name)
-		colType.Data = append(colType.Data, r.Type)
-		colOrg.Data = append(colOrg.Data, r.Org)
-		colURL.Data = append(colURL.Data, r.URL)
+		colName.Data = append(colName.Data, r.Config.Name)
+		colType.Data = append(colType.Data, r.Config.Type)
+		colOrg.Data = append(colOrg.Data, r.Config.Org)
+		colURL.Data = append(colURL.Data, r.Config.URL)
 	}
 
-	tableToPrint := []util.TableColumn{colName, colType, colOrg, colURL}
-	util.PrintTable(tableToPrint)
+	tableToPrint := []*util.TableColumn{colName, colType, colOrg, colURL}
+	util.PrintTable(tableToPrint, nil)
 }
 
 func listRegistries() {
@@ -139,9 +138,7 @@ func listRegistries() {
 	}
 	if len(regList) > 0 {
 		fmt.Println("Found registries already in config:")
-		for _, r := range regList {
-			fmt.Printf("name: %v - type: %v - organization: %v - URL: %v\n", r.Config.Name, r.Config.Type, r.Config.Org, r.Config.URL)
-		}
+		printRegistries(regList)
 	} else {
 		fmt.Println("Found no registries in configuration. Try `sbcli registry add`.")
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,8 +19,6 @@ package cmd
 import (
 	"os"
 
-	"github.com/automationbroker/bundle-lib/bundle"
-	"github.com/automationbroker/bundle-lib/registries"
 	homedir "github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -32,12 +30,6 @@ var Verbose bool
 
 // CfgFile is the configuration file
 var CfgFile string
-
-// Config sbcli configuration
-type Config struct {
-	Registries []registries.Config
-	Specs      []*bundle.Spec
-}
 
 var rootCmd = &cobra.Command{
 	Use:   "sbcli",

--- a/util/table_printer.go
+++ b/util/table_printer.go
@@ -28,30 +28,14 @@ type TableColumn struct {
 	Data   []string
 }
 
-// TableSettings provides an optional way to change default PrintTable() settings
-type TableSettings struct {
-	BaseFormatString string
-	DividerString    string
-}
-
 // Default table formatting
-const defaultBaseFormatString = " %%-%ss  "
-const defaultDividerString = " | "
+const baseFormatString = " %%-%ss  "
+const headerDivider = "   "
+const dividerDivider = "-+-"
+const contentDivider = " | "
 
 // PrintTable prints a list of TableColumns with auto-sized columns and dividers.
-func PrintTable(columns []*TableColumn, settings *TableSettings) {
-	// Define table formatting
-	var baseFormatString string
-	var dividerString string
-
-	if settings == nil {
-		baseFormatString = defaultBaseFormatString
-		dividerString = defaultDividerString
-	} else {
-		baseFormatString = settings.BaseFormatString
-		dividerString = settings.DividerString
-	}
-
+func PrintTable(columns []*TableColumn) {
 	// Vars for keeping track of column widths
 	columnWidth := make(map[string]int)
 	columnWidthStr := make(map[string]string)
@@ -70,7 +54,7 @@ func PrintTable(columns []*TableColumn, settings *TableSettings) {
 	for i, column := range columns {
 		formatString := fmt.Sprintf(baseFormatString, columnWidthStr[column.Header])
 		if i < (len(columns)) && i > 0 {
-			fmt.Print(dividerString)
+			fmt.Print(headerDivider)
 		}
 		fmt.Printf(formatString, column.Header)
 	}
@@ -80,7 +64,7 @@ func PrintTable(columns []*TableColumn, settings *TableSettings) {
 	for i, column := range columns {
 		formatString := fmt.Sprintf(baseFormatString, columnWidthStr[column.Header])
 		if i < (len(columns)) && i > 0 {
-			fmt.Print(dividerString)
+			fmt.Print(dividerDivider)
 		}
 		fmt.Printf(formatString, strings.Repeat("-", columnWidth[column.Header]))
 	}
@@ -91,7 +75,7 @@ func PrintTable(columns []*TableColumn, settings *TableSettings) {
 		for i, column := range columns {
 			formatString := fmt.Sprintf(baseFormatString, columnWidthStr[column.Header])
 			if i < (len(columns)) && i > 0 {
-				fmt.Print(dividerString)
+				fmt.Print(contentDivider)
 			}
 			fmt.Printf(formatString, column.Data[rowIndex])
 		}

--- a/util/table_printer.go
+++ b/util/table_printer.go
@@ -28,18 +28,36 @@ type TableColumn struct {
 	Data   []string
 }
 
-// PrintTable prints a list of TableColumns to the CLI with auto-sized columns and dividers
-func PrintTable(tableColumns []TableColumn) {
+// TableSettings provides an optional way to change default PrintTable() settings
+type TableSettings struct {
+	BaseFormatString string
+	DividerString    string
+}
+
+// Default table formatting
+const defaultBaseFormatString = " %%-%ss  "
+const defaultDividerString = " | "
+
+// PrintTable prints a list of TableColumns with auto-sized columns and dividers.
+func PrintTable(columns []*TableColumn, settings *TableSettings) {
 	// Define table formatting
-	baseFormatString := " %%-%ss  "
-	dividerString := " | "
+	var baseFormatString string
+	var dividerString string
+
+	if settings == nil {
+		baseFormatString = defaultBaseFormatString
+		dividerString = defaultDividerString
+	} else {
+		baseFormatString = settings.BaseFormatString
+		dividerString = settings.DividerString
+	}
 
 	// Vars for keeping track of column widths
 	columnWidth := make(map[string]int)
 	columnWidthStr := make(map[string]string)
 
 	// Set appropriate column width for all columns
-	for _, column := range tableColumns {
+	for _, column := range columns {
 		for _, cellData := range column.Data {
 			if len(cellData) > columnWidth[column.Header] {
 				columnWidth[column.Header] = len(cellData)
@@ -49,9 +67,9 @@ func PrintTable(tableColumns []TableColumn) {
 	}
 
 	// Print column header
-	for i, column := range tableColumns {
+	for i, column := range columns {
 		formatString := fmt.Sprintf(baseFormatString, columnWidthStr[column.Header])
-		if i < (len(tableColumns)) && i > 0 {
+		if i < (len(columns)) && i > 0 {
 			fmt.Print(dividerString)
 		}
 		fmt.Printf(formatString, column.Header)
@@ -59,9 +77,9 @@ func PrintTable(tableColumns []TableColumn) {
 	fmt.Println()
 
 	// Print header to content divider (---)
-	for i, column := range tableColumns {
+	for i, column := range columns {
 		formatString := fmt.Sprintf(baseFormatString, columnWidthStr[column.Header])
-		if i < (len(tableColumns)) && i > 0 {
+		if i < (len(columns)) && i > 0 {
 			fmt.Print(dividerString)
 		}
 		fmt.Printf(formatString, strings.Repeat("-", columnWidth[column.Header]))
@@ -69,10 +87,10 @@ func PrintTable(tableColumns []TableColumn) {
 	fmt.Println()
 
 	// Print table contents
-	for rowIndex := range tableColumns[0].Data {
-		for i, column := range tableColumns {
+	for rowIndex := range columns[0].Data {
+		for i, column := range columns {
 			formatString := fmt.Sprintf(baseFormatString, columnWidthStr[column.Header])
-			if i < (len(tableColumns)) && i > 0 {
+			if i < (len(columns)) && i > 0 {
 				fmt.Print(dividerString)
 			}
 			fmt.Printf(formatString, column.Data[rowIndex])


### PR DESCRIPTION
 - Move specs to reside under registries in the config file.
 - Add "REGISTRY" header to `sbcli list`
 - `sbcli list` will automatically retrieve new specs for any empty registries found in the config file
 - Add some printing functionality 