### PR TITLE
Add registry flags to "bundle" commands

### DIFF
--- a/cmd/binding.go
+++ b/cmd/binding.go
@@ -38,8 +38,8 @@ var bindingCmd = &cobra.Command{
 
 var bindingAddCmd = &cobra.Command{
 	Use:   "add <secret name> <app name>",
-	Short: "Add a new registry adapter",
-	Long:  `Add a new registry adapter to the configuration`,
+	Short: "Create a new binding",
+	Long:  `Create a new binding secret`,
 	Args:  cobra.MinimumNArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		addBinding(args)
@@ -48,8 +48,8 @@ var bindingAddCmd = &cobra.Command{
 
 var bindingRemoveCmd = &cobra.Command{
 	Use:   "remove",
-	Short: "Remove a registry adapter",
-	Long:  `Remove a registry adapter from stored configuration`,
+	Short: "Remove a binding",
+	Long:  `Remove a binding secret`,
 	Run: func(cmd *cobra.Command, args []string) {
 		removeBinding()
 	},

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -68,7 +68,7 @@ var bundleProvisionCmd = &cobra.Command{
 	Long:  `Provision ServiceBundles from a registry adapter`,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		runner.RunBundle("provision", bundleNamespace, args[0], sandboxRole, args[1:])
+		runner.RunBundle("provision", bundleNamespace, args[0], sandboxRole, bundleRegistry, args[1:])
 	},
 }
 
@@ -78,7 +78,7 @@ var bundleDeprovisionCmd = &cobra.Command{
 	Long:  `Deprovision ServiceBundles from a registry adapter`,
 	Args:  cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		runner.RunBundle("deprovision", bundleNamespace, args[0], sandboxRole, args[1:])
+		runner.RunBundle("deprovision", bundleNamespace, args[0], sandboxRole, bundleRegistry, args[1:])
 	},
 }
 
@@ -93,11 +93,13 @@ func init() {
 
 	bundleProvisionCmd.Flags().StringVarP(&bundleNamespace, "namespace", "n", "", "Namespace to provision bundle to")
 	bundleProvisionCmd.Flags().StringVarP(&sandboxRole, "role", "r", "edit", "ClusterRole to be applied to Bundle sandbox")
+	bundleProvisionCmd.Flags().StringVarP(&bundleRegistry, "registry", "", "", "Registry to load bundle from")
 	bundleProvisionCmd.MarkFlagRequired("namespace")
 	bundleCmd.AddCommand(bundleProvisionCmd)
 
 	bundleDeprovisionCmd.Flags().StringVarP(&bundleNamespace, "namespace", "n", "", "Namespace to provision bundle to")
 	bundleDeprovisionCmd.Flags().StringVarP(&sandboxRole, "role", "r", "edit", "ClusterRole to be applied to Bundle sandbox")
+	bundleDeprovisionCmd.Flags().StringVarP(&bundleRegistry, "registry", "", "", "Registry to load bundle from")
 	bundleDeprovisionCmd.MarkFlagRequired("namespace")
 	bundleCmd.AddCommand(bundleDeprovisionCmd)
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -65,7 +65,7 @@ func RunBundle(action string, ns string, bundleName string, sandboxRole string, 
 		// TODO: return an ErrorBundleNotFound
 	}
 	if len(candidateSpecs) > 1 {
-		log.Warnf("Found multiple bundles matching name [%v]. Specify a registry with -r or --registry.", bundleName)
+		log.Warnf("Found multiple bundles matching name [%v]. Specify a registry with --registry.", bundleName)
 		return
 	}
 

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -38,24 +38,38 @@ import (
 )
 
 // RunBundle will run the bundle's action in the given namespace
-func RunBundle(action string, ns string, bundleName string, sandboxRole string, args []string) {
+func RunBundle(action string, ns string, bundleName string, sandboxRole string, bundleRegistry string, args []string) {
 	reg := []Registry{}
 	var targetSpec *bundle.Spec
+	var candidateSpecs []*bundle.Spec
 	pn := fmt.Sprintf("bundle-%s", uuid.New())
 	viper.UnmarshalKey("Registries", &reg)
 	for _, r := range reg {
+		if len(bundleRegistry) > 0 && r.Config.Name != bundleRegistry {
+			continue
+		}
 		for _, s := range r.Specs {
 			if s.FQName == bundleName {
-				targetSpec = s
+				candidateSpecs = append(candidateSpecs, s)
+				fmt.Printf("Found bundle [%v] in registry [%v]\n", bundleName, r.Config.Name)
 			}
 		}
 	}
-	if targetSpec == nil {
-		log.Errorf("Didn't find supplied APB: %v\n", bundleName)
-
+	if len(candidateSpecs) == 0 {
+		if len(bundleRegistry) > 0 {
+			log.Errorf("Didn't find bundle [%v] in registry [%v]\n", bundleName, bundleRegistry)
+			return
+		}
+		log.Errorf("Didn't find bundle [%v] in configured registries\n", bundleName)
+		return
 		// TODO: return an ErrorBundleNotFound
+	}
+	if len(candidateSpecs) > 1 {
+		log.Warnf("Found multiple bundles matching name [%v]. Specify a registry with -r or --registry.", bundleName)
 		return
 	}
+
+	targetSpec = candidateSpecs[0]
 
 	// determine the correct plan
 	plan := selectPlan(targetSpec)


### PR DESCRIPTION
 - Add ability to specify registry when performing `provision`/`deprovision`
 - Fix typo in `binding` command description (looks like it was previously copied from the `registry` command desc)