### PR TITLE
Update cached bundle spec metadata when a new registry is added.

### DIFF
--- a/cmd/registry.go
+++ b/cmd/registry.go
@@ -109,6 +109,7 @@ func addRegistry() {
 	}
 	regList = append(regList, registryConfig)
 	updateCachedRegistries(regList)
+	ListImages()
 	return
 }
 


### PR DESCRIPTION
 - Exported `ListImages` function from bundle.go to be used by registry.go
 - Moved `ListImages` to the top of bundle.go (felt right to me, but open to correction if this goes against convention)
