### PR TITLE
Add OpenShift build instructions to "bundle prepare"

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -298,7 +298,13 @@ func stampBundleMetadata(bundleMetaFilename string, containerMetaFilename string
 		log.Errorf("Container metadata file [%s] could not be written", containerMetaFilename)
 		return
 	}
-	fmt.Printf("Wrote b64 encoded [%s] to [%s]\n", bundleMetaFilename, containerMetaFilename)
+	fmt.Printf("Wrote b64 encoded [%s] to [%s]\n\n", bundleMetaFilename, containerMetaFilename)
+
+	buildConfigCmd := `oc new-build . --to <bundle-name>`
+	fmt.Printf("Create a buildconfig:\n%s\n\n", buildConfigCmd)
+
+	buildTriggerCmd := `oc start-build --from-dir . <bundle-name>`
+	fmt.Printf("Start a build:\n%s\n\n", buildTriggerCmd)
 }
 
 func addBundleMetadata(bMeta []byte, cMeta []byte) []byte {


### PR DESCRIPTION
Change `sbcli bundle prepare` output to include OpenShift build commands:
```
[dwhatley@precision-t ST2]$ sbcli bundle prepare
Wrote b64 encoded [apb.yml] to [Dockerfile]

Create a buildconfig:
oc new-build . --to <bundle-name>

Start a build:
oc start-build --from-dir . <bundle-name>
```

Spoke with @dymurray about eventually hooking into the OpenShift rest calls so that we can provide an actual `build` command that creates a buildconfig and triggers a build automatically. These commands _should_ allow users to build bundles without root privs in the meantime.